### PR TITLE
Fixed multi-line closure body parsing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,8 +91,8 @@ pub mod imp {
     #[doc(hidden)]
     #[macro_export]
     macro_rules! convert_function {
-        (|$var:ident $(: $_:ty)?| -> $__:ty { $($body:tt)* }) => {
-            $crate::convert_function!(|$var| { $($body)* })
+        (|$var:ident $(: $_:ty)?| -> $__:ty $body:block) => {
+            $crate::convert_function!(|$var| $body)
         };
         (|$var:ident $(: $_:ty)?| $body:expr) => {
             /// # Safety

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,8 +91,8 @@ pub mod imp {
     #[doc(hidden)]
     #[macro_export]
     macro_rules! convert_function {
-        (|$var:ident $(: $_:ty)?| -> $__:ty { $body:expr }) => {
-            $crate::convert_function!(|$var| $body)
+        (|$var:ident $(: $_:ty)?| -> $__:ty { $($body:tt)* }) => {
+            $crate::convert_function!(|$var| { $($body)* })
         };
         (|$var:ident $(: $_:ty)?| $body:expr) => {
             /// # Safety

--- a/tests/module_tests.rs
+++ b/tests/module_tests.rs
@@ -19,6 +19,11 @@ const MULTIPLES_OF_2_TYPES: [u8; 50] = from_const_fn!(|n: usize| -> u8 { n as u8
 // Checks that the macro is using `$ty` not `$ident` (thanks u/AlxandrHeintz)
 const MULTIPLES_OF_2_TYPES_GEN: [u8; 50] =
     from_const_fn!(|n: alias::Alias<usize>| -> alias::Alias<u8> { n as u8 * 2 });
+// Ensure a multi-line body works
+const MULTIPLES_OF_2_TYPES_COMPLEX_BODY: [u8; 50] = from_const_fn!(|n| -> u8 {
+    let n_cast = n as u8;
+    n_cast * 2
+});
 
 #[test]
 fn check_correct_generation() {
@@ -33,6 +38,7 @@ fn check_correct_generation() {
     assert_eq!(correct, MULTIPLES_OF_2_TYPE);
     assert_eq!(correct, MULTIPLES_OF_2_TYPES);
     assert_eq!(correct, MULTIPLES_OF_2_TYPES_GEN);
+    assert_eq!(correct, MULTIPLES_OF_2_TYPES_COMPLEX_BODY);
 }
 
 #[cfg(feature = "drop_guard")]


### PR DESCRIPTION
I have a macro invocation like this:

```rust
const FOO: [u8; 50] = from_const_fn!(|n| -> u8 {
    let n = n as u8;
    n * 2
});
```

It doesn't compile because the `convert_function` branch 1 cannot match this pattern.

```rust
macro_rules! convert_function {
        (|$var:ident $(: $_:ty)?| -> $__:ty { $body:expr }) => {
            $crate::convert_function!(|$var| $body)
        };
        // ...
};
```

The `$body:expr` cannot match the pattern inside the brace. I replaced it with `$($body:tt)*` to fix the problem.