### PR TITLE
Added support for the wildcard parameter `_`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,9 @@ pub mod imp {
     #[doc(hidden)]
     #[macro_export]
     macro_rules! convert_function {
+        (|_| $($rest:tt)*) => {
+            $crate::convert_function!(|__| $($rest)*)
+        };
         (|$var:ident $(: $_:ty)?| -> $__:ty $body:block) => {
             $crate::convert_function!(|$var| $body)
         };

--- a/tests/module_tests.rs
+++ b/tests/module_tests.rs
@@ -51,16 +51,19 @@ fn check_correct_generation() {
     assert_eq!([35; 50], WILDCARD_CLOSURE_BLOCK);
     assert_eq!([35; 50], WILDCARD_CLOSURE_TYPE);
 
-    struct SyncUnsafeCell(UnsafeCell<u8>);
-    // SAFETY: Haha nope
-    unsafe impl Sync for SyncUnsafeCell {}
-    static COUNTER: SyncUnsafeCell = SyncUnsafeCell(UnsafeCell::new(0));
-    let wildcard_closure_counting: [u8; 50] = from_const_fn!(|_| {
-        let n = COUNTER.0.get();
-        *n += 2;
-        *n - 2
-    });
-    assert_eq!(correct, wildcard_closure_counting);
+    #[cfg(feature = "drop_guard")]
+    {
+        struct SyncUnsafeCell(UnsafeCell<u8>);
+        // SAFETY: Haha nope
+        unsafe impl Sync for SyncUnsafeCell {}
+        static COUNTER: SyncUnsafeCell = SyncUnsafeCell(UnsafeCell::new(0));
+        let wildcard_closure_counting: [u8; 50] = from_const_fn!(|_| {
+            let n = COUNTER.0.get();
+            *n += 2;
+            *n - 2
+        });
+        assert_eq!(correct, wildcard_closure_counting);
+    }
 }
 
 #[cfg(feature = "drop_guard")]

--- a/tests/module_tests.rs
+++ b/tests/module_tests.rs
@@ -1,3 +1,4 @@
+use core::cell::UnsafeCell;
 use from_const_fn::from_const_fn;
 
 mod alias {
@@ -49,6 +50,17 @@ fn check_correct_generation() {
     assert_eq!([35; 50], WILDCARD_CLOSURE);
     assert_eq!([35; 50], WILDCARD_CLOSURE_BLOCK);
     assert_eq!([35; 50], WILDCARD_CLOSURE_TYPE);
+
+    struct SyncUnsafeCell(UnsafeCell<u8>);
+    // SAFETY: Haha nope
+    unsafe impl Sync for SyncUnsafeCell {}
+    static COUNTER: SyncUnsafeCell = SyncUnsafeCell(UnsafeCell::new(0));
+    let wildcard_closure_counting: [u8; 50] = from_const_fn!(|_| {
+        let n = COUNTER.0.get();
+        *n += 2;
+        *n - 2
+    });
+    assert_eq!(correct, wildcard_closure_counting);
 }
 
 #[cfg(feature = "drop_guard")]

--- a/tests/module_tests.rs
+++ b/tests/module_tests.rs
@@ -14,6 +14,7 @@ const MULTIPLES_OF_2_BLOCK: [u8; 50] = from_const_fn!(|n| {
     let n_cast = n as u8;
     n_cast * 2
 });
+
 const MULTIPLES_OF_2_TYPE: [u8; 50] = from_const_fn!(|n: usize| n as u8 * 2);
 const MULTIPLES_OF_2_TYPES: [u8; 50] = from_const_fn!(|n: usize| -> u8 { n as u8 * 2 });
 // Checks that the macro is using `$ty` not `$ident` (thanks u/AlxandrHeintz)
@@ -25,6 +26,10 @@ const MULTIPLES_OF_2_TYPES_COMPLEX_BODY: [u8; 50] = from_const_fn!(|n| -> u8 {
     n_cast * 2
 });
 
+const WILDCARD_CLOSURE: [u8; 50] = from_const_fn!(|_| 35);
+const WILDCARD_CLOSURE_BLOCK: [u8; 50] = from_const_fn!(|_| { 35 });
+const WILDCARD_CLOSURE_TYPE: [u8; 50] = from_const_fn!(|_| -> u8 { 35 });
+
 #[test]
 fn check_correct_generation() {
     let correct: [u8; 50] = [
@@ -35,10 +40,15 @@ fn check_correct_generation() {
     assert_eq!(correct, MULTIPLES_OF_2_FN);
     assert_eq!(correct, MULTIPLES_OF_2);
     assert_eq!(correct, MULTIPLES_OF_2_BLOCK);
+
     assert_eq!(correct, MULTIPLES_OF_2_TYPE);
     assert_eq!(correct, MULTIPLES_OF_2_TYPES);
     assert_eq!(correct, MULTIPLES_OF_2_TYPES_GEN);
     assert_eq!(correct, MULTIPLES_OF_2_TYPES_COMPLEX_BODY);
+
+    assert_eq!([35; 50], WILDCARD_CLOSURE);
+    assert_eq!([35; 50], WILDCARD_CLOSURE_BLOCK);
+    assert_eq!([35; 50], WILDCARD_CLOSURE_TYPE);
 }
 
 #[cfg(feature = "drop_guard")]


### PR DESCRIPTION
The wildcard is of designator `pat_param` (or `pat`) rather than `ident` so doesn't get picked up by the existing branches and instead needs its own. I've made this branch just convert it into a double underscore which is an `ident` so it should then work.

I believe in practice this is the only `pat_param` we can take because our argument must be of type `usize` or an alias of `usize` so can't be an enum like `Some(n): Option<u32>` or a struct like `Foo { n }: Foo`.

I see little practical use for this because the only way I've found of making the value change is `SyncUnsafeCell` which only works at runtime because otherwise it complains about mutating global memory (although there may be some way to use something like `const_random`, I'm not sure). However it ultimately isn't very hard to support so we might as well.