### PR TITLE
Ensured warnings about `unsafe` not in `unsafe` blocks with passed closures.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,8 +79,9 @@ macro_rules! from_const_fn {
             unsafe { $crate::imp::transmute_const(array) }
         }
 
+        let cb = $($cb)*;
         // SAFETY: `$cb` is the passed function so it returns the same type.
-        unsafe { from_const_fn(::core::mem::ManuallyDrop::new($($cb)*)) }
+        unsafe { from_const_fn(::core::mem::ManuallyDrop::new(cb)) }
     }};
 }
 

--- a/tests/module_tests.rs
+++ b/tests/module_tests.rs
@@ -1,4 +1,3 @@
-use core::cell::UnsafeCell;
 use from_const_fn::from_const_fn;
 
 mod alias {
@@ -53,14 +52,15 @@ fn check_correct_generation() {
 
     #[cfg(feature = "drop_guard")]
     {
+        use core::cell::UnsafeCell;
         struct SyncUnsafeCell(UnsafeCell<u8>);
         // SAFETY: Haha nope
         unsafe impl Sync for SyncUnsafeCell {}
         static COUNTER: SyncUnsafeCell = SyncUnsafeCell(UnsafeCell::new(0));
         let wildcard_closure_counting: [u8; 50] = from_const_fn!(|_| {
             let n = COUNTER.0.get();
-            *n += 2;
-            *n - 2
+            unsafe { *n += 2 };
+            unsafe { *n - 2 }
         });
         assert_eq!(correct, wildcard_closure_counting);
     }


### PR DESCRIPTION
Moved the creation of the callback closure `cb` when its passed into `from_const_fn` so that it happens outside the `unsafe` block. 
This is necessary because until 2024 edition `unsafe_op_in_unsafe_fn` isn't enabled by default so the `let body = $body` in `callback` wouldn't lint. The line in `callback` is still necessary though to stop `unused_unsafe` from triggering.